### PR TITLE
Add missing install lifecycle scripts to InstallScripts heuristics

### DIFF
--- a/lib/heuristics/installScripts/index.js
+++ b/lib/heuristics/installScripts/index.js
@@ -24,7 +24,7 @@ const reference = 'https://blog.usejournal.com/12-strange-things-that-can-happen
 function run (packageName, filePath) {
   const data = fs.readFileSync(filePath, 'utf8')
   const packageManifest = JSON.parse(data)
-  const installScripts = ['preinstall', 'install', 'postinstall', 'preuninstall', 'postuninstall']
+  const installScripts = ['preinstall', 'install', 'postinstall', 'preuninstall', 'postuninstall', 'prepublish', 'preprepare', 'prepare', 'postprepare']
   let result = null
 
   if (packageManifest.scripts && Object.keys(packageManifest.scripts).some(script => installScripts.includes(script))) {


### PR DESCRIPTION
According to [NPM's scripts documentation](https://docs.npmjs.com/cli/v7/using-npm/scripts#npm-install), the following lifecycle scripts will run when `npm install` is used:

<img width="673" alt="Screen Shot 2021-07-07 at 6 06 55 p m" src="https://user-images.githubusercontent.com/44826516/124842984-20765080-df4e-11eb-8fb9-c3824c8722e9.png">

However, this tool currently only checks for preinstall, install, postinstall, preuninstall, and postuninstall. So we can evade npm-scan's InstallScripts detection heuristic by including our install script in a `prepare` script, for example. To demonstrate that `prepare` scripts really do run after `npm install` is called:

```sh
%> cat package.json
{
  "name": "evade-npm-scan",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "prepare": "echo 'haha, our install script has not been detected!' > evil.log"
  },
  "author": "",
  "license": "ISC"
}
%> npm install

> evade-npm-scan@1.0.0 prepare
> echo 'haha, our install script has not been detected!' > evil.log


up to date, audited 1 package in 138ms

found 0 vulnerabilities
%> evade-npm-scan cat evil.log
haha, our install script has not been detected!
```